### PR TITLE
Liquidize with strip html

### DIFF
--- a/lib/liquid_markdown/keys.rb
+++ b/lib/liquid_markdown/keys.rb
@@ -1,0 +1,18 @@
+module LiquidMarkdown
+  class Keys
+    # convert keys from symbol to string
+    # Example:
+    # {a: {b: 'c'}} => {'a' => {'b' => 'c'}}
+    def self.deep_stringify_keys(hash)
+      s2s = -> (h) do
+        Hash === h ?
+            Hash[
+                h.map do |k, v|
+                  [k.respond_to?(:to_sym) ? k.to_s : k, s2s[v]]
+                end
+            ] : h
+      end
+      s2s[hash]
+    end
+  end
+end

--- a/lib/liquid_markdown/render_template.rb
+++ b/lib/liquid_markdown/render_template.rb
@@ -27,8 +27,8 @@ module LiquidMarkdown
       end
 
       def liquidize
-        template = Liquid::Template.parse(@template)
-        template.render(stringify_keys(@values), LIQUID_OPTIONS)
+        t = Liquid::Template.parse(@template)
+        t.render(stringify_keys(@values), LIQUID_OPTIONS)
       end
 
       # convert key symbols to strings (required for converting values in liquidize render call)

--- a/lib/liquid_markdown/render_template.rb
+++ b/lib/liquid_markdown/render_template.rb
@@ -2,6 +2,8 @@ require 'redcarpet'
 require 'redcarpet/render_strip'
 require 'redcarpet/render_man'
 require 'liquid'
+require 'liquid_markdown/strip'
+require 'liquid_markdown/keys'
 
 module LiquidMarkdown
   module Render
@@ -28,43 +30,19 @@ module LiquidMarkdown
 
       def liquidize
         t = Liquid::Template.parse(@template)
-        val = strip_html_values(@values)
+        val = strip_html(@values)
         val = deep_stringify_keys(val)
         t.render(val, LIQUID_OPTIONS)
       end
 
       private
 
-      # convert key symbols to strings (required for converting values in liquidize render call)
-      # Example:
-      # {a: 'b'} => {'a' => 'b'}
-      def deep_stringify_keys(hash)
-        s2s = lambda do |h|
-                Hash === h ?
-                  Hash[
-                      h.map do |k, v|
-                        [k.respond_to?(:to_sym) ? k.to_s : k, s2s[v]]
-                      end
-                  ] : h
-              end
-        s2s[hash]
+      def deep_stringify_keys(input_hash)
+        LiquidMarkdown::Keys.deep_stringify_keys(input_hash)
       end
 
-      def strip_html_values(hash)
-        hash.each do |k, v|
-          if v.is_a?(String)
-            v.replace(strip_html(v))
-          elsif v.is_a?(Hash)
-            strip_html_values(v)
-          elsif v.is_a?(Array)
-            v.flatten.each { |x| strip_html_values(x) if x.is_a?(Hash) }
-          end
-        end
-      end
-
-      def strip_html(input)
-        empty = ''.freeze
-        input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty)
+      def strip_html(input_hash)
+        LiquidMarkdown::Strip.strip_html_values(input_hash)
       end
     end
   end

--- a/lib/liquid_markdown/render_template.rb
+++ b/lib/liquid_markdown/render_template.rb
@@ -28,16 +28,43 @@ module LiquidMarkdown
 
       def liquidize
         t = Liquid::Template.parse(@template)
-        t.render(stringify_keys(@values), LIQUID_OPTIONS)
+        val = strip_html_values(@values)
+        val = deep_stringify_keys(val)
+        t.render(val, LIQUID_OPTIONS)
       end
+
+      private
 
       # convert key symbols to strings (required for converting values in liquidize render call)
       # Example:
       # {a: 'b'} => {'a' => 'b'}
-      def stringify_keys(hash)
-        new_hash = {}
-        hash.each {|k, v| new_hash[k.to_s] = v}
-        new_hash
+      def deep_stringify_keys(hash)
+        s2s = lambda do |h|
+                Hash === h ?
+                  Hash[
+                      h.map do |k, v|
+                        [k.respond_to?(:to_sym) ? k.to_s : k, s2s[v]]
+                      end
+                  ] : h
+              end
+        s2s[hash]
+      end
+
+      def strip_html_values(hash)
+        hash.each do |k, v|
+          if v.is_a?(String)
+            v.replace(strip_html(v))
+          elsif v.is_a?(Hash)
+            strip_html_values(v)
+          elsif v.is_a?(Array)
+            v.flatten.each { |x| strip_html_values(x) if x.is_a?(Hash) }
+          end
+        end
+      end
+
+      def strip_html(input)
+        empty = ''.freeze
+        input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty)
       end
     end
   end

--- a/lib/liquid_markdown/strip.rb
+++ b/lib/liquid_markdown/strip.rb
@@ -1,0 +1,20 @@
+module LiquidMarkdown
+  class Strip
+    def self.strip_html_values(hash)
+      hash.each do |k, v|
+        if v.is_a?(String)
+          v.replace(strip_html(v))
+        elsif v.is_a?(Hash)
+          strip_html_values(v)
+        elsif v.is_a?(Array)
+          v.flatten.each { |x| strip_html_values(x) if x.is_a?(Hash) }
+        end
+      end
+    end
+
+    def self.strip_html(input)
+      empty = ''.freeze
+      input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty)
+    end
+  end
+end

--- a/spec/liquid_markdown/render_template_spec.rb
+++ b/spec/liquid_markdown/render_template_spec.rb
@@ -29,6 +29,11 @@ describe LiquidMarkdown::Render::Template do
       lm = subject.new('Hello {{name}}!', name: 'guest')
       expect(lm.liquidize).to eq('Hello guest!')
     end
+
+    it 'deeply nested hash values should be valid' do
+      lm = subject.new('Hello {{user.profile.info.name}}!', {user: {profile: {info: {name: 'admin'}}}})
+      expect(lm.liquidize).to eq('Hello admin!')
+    end
   end
 
   context '.render' do

--- a/spec/liquid_markdown_spec.rb
+++ b/spec/liquid_markdown_spec.rb
@@ -6,11 +6,29 @@ describe LiquidMarkdown do
   end
 
   it 'should convert into LiquidMarkdown syntax' do
-    input = '### h3 tag
+    template = '### h3 tag
   I love {{fruit.name}}!'
 
     output = "<h3>h3 tag</h3>\n\n<p>I love Orange!</p>\n"
 
-    expect(LiquidMarkdown.render(input, {'fruit' => {'name' => 'Orange'}})).to eq(output)
+    expect(LiquidMarkdown.render(template, {'fruit' => {'name' => 'Orange'}})).to eq(output)
+  end
+
+  it 'should be able to combine html and markdown together' do
+    template = '# first heading
+'
+    template += '*bold*'
+    template += '<div>Hello World</div>'
+
+    expect(LiquidMarkdown.render(template)).to eq("<h1>first heading</h1>\n\n<p><em>bold</em><div>Hello World</div></p>\n")
+  end
+
+  it 'should be able to combine html, markdown and liquid together' do
+    template = '# List of products
+'
+    template += '<ul id="products"><li><h2>{{ product.name }}</h2>Only {{ product.price | price }}</li></ul>'
+
+    expect(LiquidMarkdown.render(template, {'product' => {'name' => 'Galaxy S7 Edge', 'price' => 1200}}))
+        .to eq("<h1>List of products</h1>\n\n<ul id=\"products\"><li><h2>Galaxy S7 Edge</h2>Only 1200</li></ul>\n")
   end
 end

--- a/spec/liquid_markdown_spec.rb
+++ b/spec/liquid_markdown_spec.rb
@@ -31,4 +31,11 @@ describe LiquidMarkdown do
     expect(LiquidMarkdown.render(template, {'product' => {'name' => 'Galaxy S7 Edge', 'price' => 1200}}))
         .to eq("<h1>List of products</h1>\n\n<ul id=\"products\"><li><h2>Galaxy S7 Edge</h2>Only 1200</li></ul>\n")
   end
+
+  it 'should force strip_html filter for all variables when rendering liquid' do
+    template = 'Strip html content from: {{content}}'
+
+    expect(LiquidMarkdown.render(template, {'content' => '<html><script>alert("hello")</script><style>#alert{padding: 0;}</style><body><p>Content with html tags in it</p></body></html>'}))
+        .to eq("<p>Strip html content from: Content with html tags in it</p>\n")
+  end
 end


### PR DESCRIPTION
- force strip_html for Liquid templates
- Adding more test cases
- Deep recursively convert all keys from symbol to string
